### PR TITLE
saves/loads elements_added on BloomFilters during export

### DIFF
--- a/probables/blooms/expandingbloom.py
+++ b/probables/blooms/expandingbloom.py
@@ -177,9 +177,9 @@ class ExpandingBloomFilter(object):
                 # now we need to read in the correct number of bytes...
                 offset = calcsize('Q') + calcsize('B') * blm.bloom_length
                 rep = 'Q' + 'B' * blm.bloom_length
-                elements_added, *bloom_bytes = list(unpack(rep, fileobj.read(offset)))
-                blm._bloom = bloom_bytes
-                blm.elements_added = elements_added
+                unpacked = list(unpack(rep, fileobj.read(offset)))
+                blm._bloom = unpacked[1:]
+                blm.elements_added = unpacked[0]
                 self._blooms.append(blm)
 
 

--- a/tests/expandingbloom_test.py
+++ b/tests/expandingbloom_test.py
@@ -81,14 +81,14 @@ class TestExpandingBloomFilter(unittest.TestCase):
         ''' basic expanding Bloom Filter export test '''
         blm = ExpandingBloomFilter(est_elements=25, false_positive_rate=0.05)
         blm.export('test.ebf')
-        self.assertEqual(calc_file_md5('test.ebf'), '1581beab91f83b7e5aaf0f059ee94eaf')
+        self.assertEqual(calc_file_md5('test.ebf'), 'eb5769ae9babdf7b37d6ce64d58812bc')
         os.remove('test.ebf')
 
     def test_ebf_import_empty(self):
         ''' test that expanding Bloom Filter is correct on import '''
         blm = ExpandingBloomFilter(est_elements=25, false_positive_rate=0.05)
         blm.export('test.ebf')
-        self.assertEqual(calc_file_md5('test.ebf'), '1581beab91f83b7e5aaf0f059ee94eaf')
+        self.assertEqual(calc_file_md5('test.ebf'), 'eb5769ae9babdf7b37d6ce64d58812bc')
 
         blm2 = ExpandingBloomFilter(filepath='test.ebf')
         for bloom in blm2._blooms:
@@ -217,14 +217,14 @@ class TestRotatingBloomFilter(unittest.TestCase):
         ''' basic rotating Bloom Filter export test '''
         blm = RotatingBloomFilter(est_elements=25, false_positive_rate=0.05)
         blm.export('test.rbf')
-        self.assertEqual(calc_file_md5('test.rbf'), '1581beab91f83b7e5aaf0f059ee94eaf')
+        self.assertEqual(calc_file_md5('test.rbf'), 'eb5769ae9babdf7b37d6ce64d58812bc')
         os.remove('test.rbf')
 
     def test_rbf_import_empty(self):
         ''' test that rotating Bloom Filter is correct on import '''
         blm = RotatingBloomFilter(est_elements=25, false_positive_rate=0.05)
         blm.export('test.rbf')
-        self.assertEqual(calc_file_md5('test.rbf'), '1581beab91f83b7e5aaf0f059ee94eaf')
+        self.assertEqual(calc_file_md5('test.rbf'), 'eb5769ae9babdf7b37d6ce64d58812bc')
 
         blm2 = ExpandingBloomFilter(filepath='test.rbf')
         for bloom in blm2._blooms:


### PR DESCRIPTION
When exporting a RotatingBloomFilter the bitmaps from the underlying bloom filters are saved, but the elements_added are not saved. On reloading a RotatingBloomFilter, all the BloomFilters in _blooms will have an elements_added of 0. 

If a bloom filter is frequently serialized then deserialized and the estimated elements is high enough this will cause the RotatingBloomFilter to never actually rotate the bloom filters since `ready_to_rotate = blm.elements_added == blm.estimated_elements` will not be hit.