### PR TITLE
Make MMap win32 compatible

### DIFF
--- a/probables/utilities.py
+++ b/probables/utilities.py
@@ -42,7 +42,7 @@ class MMap:
     def __init__(self, path: Union[Path, str]):
         self.__p = Path(path)
         self.__f = self.path.open("rb")
-        self.__m = mmap.mmap(self.__f.fileno(), 0, prot=mmap.PROT_READ)
+        self.__m = mmap.mmap(self.__f.fileno(), 0, access=mmap.ACCESS_READ)
         self._closed = False
 
     def __enter__(self) -> mmap.mmap:


### PR DESCRIPTION
Use the system-agnostic `access` argument instead of the posix specific `prot` when initializing mmap.

Currently when trying to load a binary file, I get this error:

```
Traceback (most recent call last):
  File "C:\Users\leonh\AppData\Local\Programs\Python\Python310\lib\multiprocessing\process.py", line 314, in _bootstrap
    self.run()
  File "C:\Users\leonh\AppData\Local\Programs\Python\Python310\lib\multiprocessing\process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "C:\Users\leonh\Documents\akyth-documents-download\program2.py", line 39, in check_seen
    seen = probables.ExpandingBloomFilter(100_000_000, 0.001, "./seen.blm")
  File "C:\Users\leonh\Documents\pyprobables\probables\blooms\expandingbloom.py", line 61, in __init__
    self.__load(filepath)
  File "C:\Users\leonh\Documents\pyprobables\probables\blooms\expandingbloom.py", line 211, in __load
    with MMap(file) as filepointer:
  File "C:\Users\leonh\Documents\pyprobables\probables\utilities.py", line 45, in __init__
    self.__m = mmap.mmap(self.__f.fileno(), 0, prot=mmap.PROT_READ)
```

I tested this again using WSL and everything worked fine. In the end this comes down to the fact that the `prot` argument in the MMap init function is POSIX-specific, while `access` serves as a system-agnostic way of doing the same thing. I changed the init line and tested this change on both windows and and WSL and this error is gone.

Here's the relevant docs for MMap: [link](https://docs.python.org/3/library/mmap.html#mmap.mmap)

Please merge ASAP as this breaks usage on windows.